### PR TITLE
Add missing auto_ptr declaration

### DIFF
--- a/commandline.cpp
+++ b/commandline.cpp
@@ -24,6 +24,7 @@
 //  Copyright (c) 2007 Intel Corp.
 
 #include "par2cmdline.h"
+#include <backward/auto_ptr.h>
 
 #if __APPLE__
   #include <sys/types.h>

--- a/par2cmdline.cpp
+++ b/par2cmdline.cpp
@@ -24,6 +24,7 @@
 //  Copyright (c) 2007 Intel Corp.
 
 #include "par2cmdline.h"
+#include <backward/auto_ptr.h>
 
 #ifdef _MSC_VER
 #ifdef _DEBUG

--- a/par2creator.cpp
+++ b/par2creator.cpp
@@ -30,6 +30,7 @@
 //  par2cmdline-0.4-tbb is available at http://chuchusoft.com/par2_tbb
 
 #include "par2cmdline.h"
+#include <backward/auto_ptr.h>
 
 #if WANT_CONCURRENT
   #if CONCURRENT_PIPELINE

--- a/par2repairer.cpp
+++ b/par2repairer.cpp
@@ -30,6 +30,7 @@
 //  par2cmdline-0.4-tbb is available at http://chuchusoft.com/par2_tbb
 
 #include "par2cmdline.h"
+#include <backward/auto_ptr.h>
 
 //static unsigned gti;
 //static tbb::atomic<unsigned> gti;


### PR DESCRIPTION
Found with gcc 4.9.2 on debian jessie.

Signed-off-by: Thomas Braun thomas.braun@byte-physics.de
